### PR TITLE
use goreleaser and resolve dependencies with go.mod

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ vendor/*
 
 # artifacts
 /builds
+dist/

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,19 @@
+builds:
+  - main: ./cmd/lolp
+    goos:
+      - darwin
+      - linux
+    goarch:
+      - amd64
+archive:
+  name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}"
+checksum:
+  name_template: 'checksums.txt'
+snapshot:
+  name_template: "{{ .Tag }}-next"
+changelog:
+  sort: asc
+  filters:
+    exclude:
+    - '^docs:'
+    - '^test:'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 language: go
 go:
-  - 1.11.x
-  - 1.10.x
-  - 1.9.x
+  - 1.13.x
+  - 1.12.x
 script:
   - make ci
 notifications:

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,7 @@ depsdev: install_goreleaser
 	go get github.com/pierrre/gotestcover
 	go get -u github.com/Songmu/ghch/cmd/ghch
 
+test: export GO111MODULE=on
 test:
 	go test $(TEST) $(TESTARGS) $(TEST_OPTIONS)
 	go test -race $(TEST) $(TESTARGS)

--- a/Makefile
+++ b/Makefile
@@ -13,14 +13,11 @@ TEST_OPTIONS=-timeout 30s -parallel $(NCPU)
 
 default: test
 
-deps:
-	go get -u github.com/golang/dep/cmd/dep
-	dep ensure
-
 install_goreleaser:
-	eval $(CMD_INSTALL_GORELEASER)
+	@which goreleaser || eval $(CMD_INSTALL_GORELEASER)
 
-depsdev: deps install_goreleaser
+depsdev: export GO111MODULE=off
+depsdev: install_goreleaser
 	go get -u golang.org/x/lint/golint
 	go get github.com/pierrre/gotestcover
 	go get -u github.com/Songmu/ghch/cmd/ghch
@@ -35,19 +32,12 @@ integration:
 lint:
 	golint -set_exit_status $(TEST)
 
-ci: deps test
+ci: test
 
-clean:
-	rm -rf ./builds
-	mkdir ./builds
+build: install_goreleaser
+	goreleaser --skip-publish --snapshot --rm-dist
 
-build: clean
-	goxz -n $(NAME) -pv $(VERSION) -d ./builds -os=linux,darwin -arch=amd64 ./cmd/lolp
+dist: install_goreleaser
+	goreleaser --rm-dist
 
-ghr:
-	ghr -u pepabo v$(VERSION) builds
-
-dist: build
-	@test -z $(GITHUB_TOKEN) || $(MAKE) ghr
-
-.PHONY: default dist test deps
+.PHONY: default dist test

--- a/Makefile
+++ b/Makefile
@@ -4,23 +4,25 @@ VERSION = "$(shell awk -F\" '/^const Version/ { print $$2; exit }' version.go)"
 
 ifeq ("$(shell uname)","Darwin")
 NCPU ?= $(shell sysctl hw.ncpu | cut -f2 -d' ')
+CMD_INSTALL_GORELEASER="brew install goreleaser"
 else
 NCPU ?= $(shell cat /proc/cpuinfo | grep processor | wc -l)
+CMD_INSTALL_GORELEASER="curl -sfL https://install.goreleaser.com/github.com/goreleaser/goreleaser.sh | sh"
 endif
 TEST_OPTIONS=-timeout 30s -parallel $(NCPU)
 
 default: test
 
-deps: export GO111MODULE=off
 deps:
 	go get -u github.com/golang/dep/cmd/dep
 	dep ensure
 
-depsdev: deps
+install_goreleaser:
+	eval $(CMD_INSTALL_GORELEASER)
+
+depsdev: deps install_goreleaser
 	go get -u golang.org/x/lint/golint
 	go get github.com/pierrre/gotestcover
-	go get -u github.com/Songmu/goxz/cmd/goxz
-	go get -u github.com/tcnksm/ghr
 	go get -u github.com/Songmu/ghch/cmd/ghch
 
 test:


### PR DESCRIPTION
- Use [`goreleaser`](https://github.com/goreleaser/goreleaser) instead of `goxz` and `ghr` for release
  - `goreleaser` can build and deploy both by itself.
- remove `make deps`, which uses [dep](https://github.com/golang/dep) and `Gopkg.toml` but golang support go.mod after `v0.12`
  - i leave `Gopkg.toml` for backward compatible.